### PR TITLE
Metadata exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added 
+* a getItemMetadata to the model that will request item metadata and attach it to item json. 
+* passing metadata to koops file exporters
+* tests for getItemMetadata
+### Changed 
+* updated calls to file export methods to have less inputs. This is in anticipation of a larger controller and model refactor that is going to happen soon.
+
+
 ## [0.3.2] - 2015-06-29
 ### Fixed
 * Fixed a bug with trying to access the maxRecordCount on service metadata when its undefined.

--- a/controller/index.js
+++ b/controller/index.js
@@ -285,7 +285,8 @@ var Controller = function( agol, BaseController ){
                 } else {
                   // Get the item
                   req.query.layer = ( !parseInt(req.params.layer)) ? 0 : req.params.layer;
-                  
+                   
+                  // if getMetadata is true then the getItem method will attach the metadata to the json 
                   req.query.getMetadata = true;
                   agol.getItem(data.host, req.params.item, req.query, function( err, itemJson ){
                     //agol.getItemData( data.host, req.params.id, req.params.item, key, req.query, function(error, itemJson){

--- a/controller/index.js
+++ b/controller/index.js
@@ -285,7 +285,8 @@ var Controller = function( agol, BaseController ){
                 } else {
                   // Get the item
                   req.query.layer = ( !parseInt(req.params.layer)) ? 0 : req.params.layer;
-
+                  
+                  req.query.getMetadata = true;
                   agol.getItem(data.host, req.params.item, req.query, function( err, itemJson ){
                     //agol.getItemData( data.host, req.params.id, req.params.item, key, req.query, function(error, itemJson){
                       if ( exists ){
@@ -398,14 +399,10 @@ var Controller = function( agol, BaseController ){
       } else {
         res.status(400).send( err );
       }
-    } 
-    else if ( itemJson && itemJson.data && itemJson.data[0] && (!itemJson.data[0].features || !itemJson.data[0].features.length)) {
-
+    } else if ( itemJson && itemJson.data && itemJson.data[0] && (!itemJson.data[0].features || !itemJson.data[0].features.length)) {
       agol.log('error', req.url +' No features in data');
       res.status(404).send( 'No features exist for the requested FeatureService layer');
-
-    } 
-    else {
+    } else {
 
       var name = ( itemJson && itemJson.data && itemJson.data[0] && (itemJson.data[0].name || (itemJson.data[0].info && itemJson.data[0].info.name) ) ) ? itemJson.data[0].name || itemJson.data[0].info.name : itemJson.name || itemJson.title;
       // cleanze the name
@@ -430,6 +427,15 @@ var Controller = function( agol, BaseController ){
 
       }
 
+      var fileParams = {
+        dir: dir,
+        key: key, 
+        id: req.params.item,
+        format: req.params.format,
+        type: 'agol',
+        data: (itemJson && itemJson.data && itemJson.data[0]) ? itemJson.data[0] : null
+      }
+
       if ((itemJson.koop_status && itemJson.koop_status == 'too big') || agol.forceExportWorker ){
         // export as a series of small queries/files
         var table = 'agol:' + req.params.item + ':' + ( req.params.layer || 0 );
@@ -439,7 +445,10 @@ var Controller = function( agol, BaseController ){
         if (itemJson.data && itemJson.data[0] && itemJson.data[0].info && itemJson.data[0].info.geometryType){
           req.query.geomType = itemJson.data[0].info.geometryType;
         }
-        agol.exportLarge( req.params.format, req.params.item, key, 'agol', req.query, function(err, result){
+        // force export of large data
+        req.query.large = true
+
+        agol.exportFile( fileParams, req.query, function(err, result){
           if (result && result.status && result.status == 'processing'){
             agol.getCount(table, {}, function(err, count){
               var code = 202;
@@ -475,17 +484,17 @@ var Controller = function( agol, BaseController ){
         });
       } else if (itemJson && itemJson.data && itemJson.data[0]) {
 
-        agol.exportToFormat( 
-          req.params.format, 
-          dir, 
-          key, 
-          itemJson.data[0], 
-          { 
-            isFiltered: req.query.isFiltered, 
-            name: name, 
-            wkid: req.query.wkid 
-          }, 
-          function(err, result){
+        var opts = {
+          isFiltered: req.query.isFiltered, 
+          name: name, 
+          wkid: req.query.wkid
+        };
+
+        if (itemJson.metadata) {
+          opts.metadata = itemJson.metadata;
+        }
+
+        agol.exportFile(fileParams, opts, function(err, result){
           if ( req.query.url_only ){
             var origUrl = req.originalUrl.split('?');
             origUrl[0] = origUrl[0].replace(/json/,req.params.format);

--- a/models/agol.js
+++ b/models/agol.js
@@ -209,8 +209,8 @@ var AGOL = function( koop ){
         if (json.error) {
           return callback(json.error.message, null);  
         }
-        if (options.getMetadata && json.typeKeywords.indexOf('Metadata') !== -1) {
-          agol.getItemMetaData( host, itemId, json, callback);
+        if (options.getMetadata && json.typeKeywords && json.typeKeywords.indexOf('Metadata') !== -1) {
+          agol.getItemMetadata( host, itemId, json, callback);
         } else {
           callback(null, json);
         }
@@ -229,7 +229,8 @@ var AGOL = function( koop ){
    * @param {object} json - an item's json data to attach metadata to 
    * @param {function} callback - the callback for when all is gone
    */
-  agol.getItemMetaData = function (host, item, json, callback) {
+  agol.getItemMetadata = function (host, item, json, callback) {
+    console.log('what')
     var url = [host, this.agol_path, item, '/info/metadata/metadata.xml?format=default'].join('');
     this.req(url, function (err, data) {
       if (err) {

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -331,7 +331,7 @@ describe('AGOL Controller', function(){
 
         var itemInfo = require('./fixtures/itemInfo.js');
 
-        sinon.stub(agol, 'exportToFormat', function(format, dir, key, data, opts, callback){
+        sinon.stub(agol, 'exportFile', function(params, opts, callback){
           callback(null, 'aFakeFile');
         });
 
@@ -353,7 +353,7 @@ describe('AGOL Controller', function(){
         agol.getItemData.restore();
         agol.getInfo.restore();
         agol.find.restore();
-        agol.exportToFormat.restore();
+        agol.exportFile.restore();
         done();
       });
 
@@ -363,7 +363,7 @@ describe('AGOL Controller', function(){
           .end(function(err, res){
             //res.should.have.status(404);
             agol.getInfo.called.should.equal(true);
-            agol.exportToFormat.called.should.equal(true);
+            agol.exportFile.called.should.equal(true);
             agol.getItemData.called.should.equal(true);
             done();
         });
@@ -376,7 +376,7 @@ describe('AGOL Controller', function(){
 
         var itemInfo = require('./fixtures/itemInfo.js');
 
-        sinon.stub(agol, 'exportLarge', function(format, dir, key, data, opts, callback){
+        sinon.stub(agol, 'exportFile', function(params, opts, callback){
           callback(null, 'aFakeLargeFile');
         });
 
@@ -398,17 +398,17 @@ describe('AGOL Controller', function(){
         agol.getItemData.restore();
         agol.getInfo.restore();
         agol.find.restore();
-        agol.exportLarge.restore();
+        agol.exportFile.restore();
         done();
       });
 
-      it('should call Exporter.exportLarge an dreturn 200', function(done){
+      it('should call Exporter.exportFile an dreturn 200', function(done){
          request(koop)
           .get('/agol/test/itemid/0.csv')
           .end(function(err, res){
             res.should.have.status(404);
             agol.getInfo.called.should.equal(true);
-            agol.exportLarge.called.should.equal(true);
+            agol.exportFile.called.should.equal(true);
             agol.getItemData.called.should.equal(true);
             done();
         });

--- a/test/fixtures/itemInfo.js
+++ b/test/fixtures/itemInfo.js
@@ -26,6 +26,7 @@ module.exports = { name: 'US Congregational Districts',
      htmlPopupType: 'esriServerHTMLPopupTypeAsHTMLText',
      displayField: 'CODE',
      typeIdField: null,
+     typeKeywords: ['Metadata'],
      fields: 
       [ [Object],
         [Object],

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -61,6 +61,35 @@ describe('AGOL Model', function(){
         });
       });
     });
+
+    describe('when getting an item with metadata', function() {
+      before(function (done) {
+        var itemInfo = require('./fixtures/itemInfo.js');
+        sinon.stub(agol, 'req', function(url, callback){
+          callback(null, {body: JSON.stringify(itemInfo.info)});
+        });
+
+        sinon.stub(agol, 'getItemMetadata', function(host, itemId, json, callback){
+          json.metadata = true;
+          callback(null, json);
+        });
+        done();
+      });
+
+      after(function (done) {
+        agol.getItemMetadata.restore();
+        agol.req.restore();
+        done();
+      });
+
+      it('should call getItemMetadata to json', function(done){
+        agol.getItem('host1', 'item1', {getMetadata: true}, function(err, json) {
+          json.metadata.should.equal(true);
+          done();
+        });
+      });
+      
+    });
    
     describe('when getting a an expired feature service item', function() {
 


### PR DESCRIPTION
adds retrieval of metadata to the model and makes the controller pass it to koop's core exporters. The exporters will see metadata and create an XML file in any shp file download. 