### PR TITLE
changing syntax for omit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Refactored `workers/request-worker.js` to extract shared code for paging feature service data.
 * Refactored `controller/index.js` to redude some of the complexity
 * Refactored `controller/index.js` to centralize logic for host lookup and cache-keying
+* Changed syntax for omitting things that shouldn't be in cache key
 
 ### Removed
 * removed the all code for talking to Feature Services from both the model and the request worker. This helps reduce the deplucation of logic and code for paging over service features. 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,7 @@ Utils.forceHttps = function (url) {
  */
 Utils.createCacheKey = function (params, query) {
   // sort the req.query before we hash so we are consistent
+  // there is a potential memory issue with using _(obj).omit(array)
   var sorted_query = _.keys(_.omit(query, ['url_only', 'format', 'callback'])).sort()
   // build the file key as an MD5 hash that's a join on the paams and look for the file
   var toHash = params.item + '_' + (params.layer || 0) + JSON.stringify(sorted_query)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ Utils.forceHttps = function (url) {
  */
 Utils.createCacheKey = function (params, query) {
   // sort the req.query before we hash so we are consistent
-  var sorted_query = _(query).omit(['url_only', 'format', 'callback']).keys().sort()
+  var sorted_query = _.keys(_.omit(query, ['url_only', 'format', 'callback'])).sort()
   // build the file key as an MD5 hash that's a join on the paams and look for the file
   var toHash = params.item + '_' + (params.layer || 0) + JSON.stringify(sorted_query)
 


### PR DESCRIPTION
I'm seeing a really strange memory issue with another repo where I use syntax like:

`_(obj).omit(array)`

I end up seeing: FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory

So just to be safe I'm changing the syntax