### PR TITLE
bump leaflet to 0.7.3 and esri-leaflet to 1.0.0 final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+* bumped version of leaflet/esri leaflet used by preview
+
 ## [1.1.3] - 2015-08-17 
 ### Fixed
 * Format is added to file name only once

--- a/views/demo.ejs
+++ b/views/demo.ejs
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" media="all" rel="stylesheet" />
-
+    <link href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" media="all" rel="stylesheet">
+    
     <style>
       input.sample-input {
         margin-bottom: 10px;
@@ -49,9 +49,9 @@
 
     <!-- Javascripts from your assets folder are included here -->
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="/js/esri-leaflet.js"></script>
+    <script src="//cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
     <script type="text/javascript" src="/js/map.js"></script>
 
     <div id="map"></div>


### PR DESCRIPTION
similar to koopjs/koop-github#22, except koop-agol doesn't have an `index.ejs`