### PR TITLE
Feature/expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 * Get endpoint for cache expiration
-* Put endpoint for cache expiration
+* Put/Post endpoint for cache expiration
 
 ### Changed
 * bumped version of leaflet/esri leaflet used by preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+* Get endpoint for cache expiration
+* Put endpoint for cache expiration
+
 ### Changed
 * bumped version of leaflet/esri leaflet used by preview
 * bumped standard to v5

--- a/models/agol.js
+++ b/models/agol.js
@@ -315,7 +315,7 @@ var AGOL = function (koop) {
       info.expires_at = expiration
       // finally update the info doc with our well-formed and validated expiration
       agol.updateInfo(key, info, function (err) {
-        callback(err)
+        callback(err, expiration)
       })
     })
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ module.exports = {
   'get /agolworkers': 'getQueueCounts',
   'get /agol/:id': 'find',
   'get /agol/:id/*': 'setHostKey',
+  'put /agol/:id/*': 'setHostKey',
   'delete /agol/:id': 'del',
   'delete /agol/:id/:item/:layer': 'deleteItemData',
   'get /agol/:id/:item/:layer/geohash': 'getGeohash',

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,5 +21,7 @@ module.exports = {
   'get /agol/:id/:item/FeatureServer/:layer': 'featureserver',
   'get /agol/:id/:item/FeatureServer/:layer/:method': 'featureserver',
   'post /agol/:id/:item/FeatureServer/:layer/:method': 'featureserver',
-  'get /agol/:id/:item/FeatureServer/:layer/geohash': 'getGeohash'
+  'get /agol/:id/:item/FeatureServer/:layer/geohash': 'getGeohash',
+  'get /agol/:id/:item/:layer/expiration': 'getExpiration',
+  'put /agol/:id/:item/:layer/expiration': 'setExpiration'
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,7 @@ module.exports = {
   'get /agol/:id': 'find',
   'get /agol/:id/*': 'setHostKey',
   'put /agol/:id/*': 'setHostKey',
+  'post /agol/:id/*': 'setHostKey',
   'delete /agol/:id': 'del',
   'delete /agol/:id/:item/:layer': 'deleteItemData',
   'get /agol/:id/:item/:layer/geohash': 'getGeohash',
@@ -24,5 +25,6 @@ module.exports = {
   'post /agol/:id/:item/FeatureServer/:layer/:method': 'featureserver',
   'get /agol/:id/:item/FeatureServer/:layer/geohash': 'getGeohash',
   'get /agol/:id/:item/:layer/expiration': 'getExpiration',
-  'put /agol/:id/:item/:layer/expiration': 'setExpiration'
+  'put /agol/:id/:item/:layer/expiration': 'setExpiration',
+  'post /agol/:id/:item/:layer/expiration': 'setExpiration'
 }

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -130,6 +130,121 @@ describe('AGOL Controller', function () {
         })
     })
   })
+
+  describe('getting a resource\'s expiration', function () {
+    before(function (done) {
+      sinon.stub(agol, 'find', function (id, callback) {
+        callback(null, 'http://www.host.com')
+      })
+      done()
+    })
+
+    after(function (done) {
+      agol.find.restore()
+      done()
+    })
+
+    it('should return 404 when the resource does not exist', function (done) {
+      sinon.stub(agol, 'getExpiration', function (key, callback) {
+        callback(new Error('Resource not found'))
+      })
+
+      request(koop)
+        .get('/agol/test/itemid/0/expiration')
+        .expect(404, 'Resource not found')
+        .end(function (err, res) {
+          agol.getExpiration.restore()
+          should.not.exist(err)
+          done()
+        })
+    })
+
+    it('should respond with a UTC String when the resource exists', function (done) {
+      var expires = new Date()
+      sinon.stub(agol, 'getExpiration', function (key, callback) {
+        callback(null, expires)
+      })
+
+      request(koop)
+        .get('/agol/test/itemid/0/expiration')
+        .end(function (err, res) {
+          agol.getExpiration.restore()
+          should.not.exist(err)
+          res.should.have.status(200)
+          var returned = new Date(res.body).toString()
+          returned.should.equal(expires.toString())
+          done()
+        })
+    })
+  })
+
+  describe('setting a resource\'s expiration', function () {
+    before(function (done) {
+      sinon.stub(agol, 'find', function (id, callback) {
+        callback(null, 'http://www.host.com')
+      })
+      done()
+    })
+
+    after(function (done) {
+      agol.find.restore()
+      done()
+    })
+
+    it('should return 400 when the inputs are malformed', function (done) {
+      sinon.stub(agol, 'setExpiration', function (key, expiration, callback) {
+        callback(new Error('Invalid input'))
+      })
+
+      request(koop)
+        .put('/agol/test/itemid/0/expiration')
+        .send('foo')
+        .expect(400, 'Invalid input')
+        .end(function (err, res) {
+          agol.setExpiration.restore()
+          should.not.exist(err)
+          done()
+        })
+    })
+
+    it('should return 200 when the inputs are well formed and the resource exists in the cache', function (done) {
+      sinon.stub(agol, 'setExpiration', function (key, expiration, callback) {
+        callback(null)
+      })
+
+      request(koop)
+        .put('/agol/test/itemid/0/expiration')
+        .send(Date.now().toString())
+        .end(function (err, res) {
+          agol.setExpiration.restore()
+          should.not.exist(err)
+          res.should.have.status(200)
+          done()
+        })
+    })
+
+    it('should return 201 and kick off a request for the remote resource if the resource is not found in the cache', function (done) {
+      sinon.stub(agol, 'setExpiration', function (key, expiration, callback) {
+        callback(new Error('Resource not found'))
+      })
+
+      sinon.stub(agol, 'getItemData', function (host, hostId, itemId, hash, options, callback) {
+        callback(null, {})
+      })
+
+      request(koop)
+        .put('/agol/test/itemid/0/expiration')
+        .send(Date.now().toString())
+        .end(function (err, res) {
+          agol.setExpiration.restore()
+          should.not.exist(err)
+          res.should.have.status(201)
+          agol.getItemData.called.should.equal(true)
+          agol.getItemData.restore()
+          done()
+        })
+    })
+  })
   describe('dropping item metadata', function () {
     before(function (done) {
       sinon.stub(agol, 'dropItem', function (host, item, options, callback) {

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -151,7 +151,7 @@ describe('AGOL Controller', function () {
 
       request(koop)
         .get('/agol/test/itemid/0/expiration')
-        .expect(404, 'Resource not found')
+        .expect(404, {error: 'Resource not found'})
         .end(function (err, res) {
           agol.getExpiration.restore()
           should.not.exist(err)
@@ -197,7 +197,7 @@ describe('AGOL Controller', function () {
       request(koop)
         .put('/agol/test/itemid/0/expiration')
         .send({expires_at: 'foo'})
-        .expect(400, 'Invalid input')
+        .expect(400, {error: 'Invalid input'})
         .end(function (err, res) {
           agol.setExpiration.restore()
           should.not.exist(err)

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -97,7 +97,7 @@ describe('AGOL Model', function () {
           callback(new Error('Resource not found'))
         })
 
-        agol.setExpiration('testkey', new Date(), function (err) {
+        agol.setExpiration('testkey', new Date('2099'), function (err) {
           should.exist(err)
           err.message.should.equal('Resource not found')
           agol.getInfo.restore()

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -90,6 +90,101 @@ describe('AGOL Model', function () {
 
   })
 
+  describe('when setting the expiration date on a resource', function () {
+    describe('that does not exist', function () {
+      it('should call back with an error', function (done) {
+        sinon.stub(agol, 'getInfo', function (key, callback) {
+          callback(new Error('Resource not found'))
+        })
+
+        agol.setExpiration('testkey', new Date(), function (err) {
+          should.exist(err)
+          err.message.should.equal('Resource not found')
+          agol.getInfo.restore()
+          done()
+        })
+      })
+    })
+
+    describe('that does exist', function () {
+      before(function (done) {
+        sinon.stub(agol, 'getInfo', function (key, callback) {
+          callback(null, {})
+        })
+        sinon.stub(agol, 'updateInfo', function (key, info, callback) {
+          callback(null)
+        })
+        done()
+      })
+
+      after(function (done) {
+        agol.getInfo.restore()
+        agol.updateInfo.restore()
+        done()
+      })
+
+      it('should update the info doc when the input is a unix timestamp', function (done) {
+        agol.setExpiration('testkey', new Date('2099').getTime(), function (err) {
+          should.not.exist(err)
+          done()
+        })
+      })
+
+      it('should update the info doc when the input is a UTC String', function (done) {
+        agol.setExpiration('testkey', new Date('2099').toString(), function (err) {
+          should.not.exist(err)
+          done()
+        })
+      })
+
+      it('should call back with an error when the input cannot be parsed into a date', function (done) {
+        agol.setExpiration('testkey', 'foo', function (err) {
+          should.exist(err)
+          err.message.should.equal('Invalid input')
+          done()
+        })
+      })
+
+      it('should callback with an error when the expiration date is in the past', function (done) {
+        agol.setExpiration('testkey', '2011', function (err) {
+          should.exist(err)
+          err.message.should.equal('Expiration cannot be in the past')
+          done()
+        })
+      })
+    })
+  })
+
+  describe('when getting the expiration date on a resource', function () {
+    it('should call back with an error when the resource does not exist', function (done) {
+      sinon.stub(agol, 'getInfo', function (key, callback) {
+        callback(new Error('Resource not found'))
+      })
+
+      agol.getExpiration('testkey', function (err, expiration) {
+        should.exist(err)
+        err.message.should.equal('Resource not found')
+        agol.getInfo.restore()
+        done()
+      })
+    })
+
+    it('should call back with a Unix timestamp from the db when the resource exists', function (done) {
+      var time = new Date().getTime()
+      sinon.stub(agol, 'getInfo', function (key, callback) {
+        var info = {expires_at: time}
+        callback(null, info)
+      })
+
+      agol.getExpiration('testkey', function (err, expiration) {
+        should.not.exist(err)
+        expiration.should.equal(time)
+        agol.getInfo.restore()
+        done()
+      })
+    })
+  })
+
   describe('when getting a an expired feature service item', function () {
     before(function (done) {
       var itemInfo = JSON.parse(fs.readFileSync(__dirname + '/fixtures/itemInfo.json').toString())


### PR DESCRIPTION
Resolves #62 

This feature allows cache expiration to be set for a resource with a call like:

```bash
curl -XPUT koop.dev/agol/arcgis/5e0112d3f694413188eff5358381fb3a/14/expiration -d '{"expires_at": "2016-08-18T13:26:40.109Z"}' -H 'Content-Type: application/json'
{"status":"processing","expires_at":"2016-08-18T13:26:40.109Z"}
```
Responses on put expiration:
- 200 -> expiration is set
- 201 -> resource did not exist in cache, expiration is set and data is requested
- 400 -> invalid input for the expiration time
- 4xx/5xx -> resource did not exist in cache, expiration is not set, failed when building a request job for the data

Getting looks like:
```bash
curl -XGET http://koop.dev/agol/arcgis/414a2d4420554720981cf4d734780957/0/expiration                                [11:33:13]
{"expires_at":"2016-08-18T13:26:40.109Z"}
```

Will respond either 200 or 404

cc @AKHarris @ngoldman 