### PR TITLE
Standardize status responses to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+* Feature service logic is fully delegated to featureservice.js
+* Extracts a method called `controller.download` that was previously subsumed in `findItemData`
+* Renamed `_returnProcessing` to `_returnStatus`, method now handles passed in errors
+* Added table keys to many logging statements
+* Resources have a status of processing or failed, check for that status at the top of any request
+
 ## [1.2.0] - 2015-08-19
 ### Added
 * Get endpoint for cache expiration

--- a/controller/index.js
+++ b/controller/index.js
@@ -394,7 +394,7 @@ var Controller = function (agol, BaseController) {
    * Stub a method for test route than can be easily wrapped
    */
   controller.testMethod = function (req, res) {
-    res.status(419).send('Nothing to see here.')
+    res.status(418).send('Nothing to see here.')
   }
 
   /**

--- a/controller/index.js
+++ b/controller/index.js
@@ -458,32 +458,12 @@ var Controller = function (agol, BaseController) {
         if (info.generating) response.generating = info.generating
 
         // tack on information from a passed in error if it's available
-        if (error && error.message) response.generating = controller._failureMsg(error)
+        if (error && error.message) response.generating = Utils.failureMsg(error)
 
         agol.log('debug', JSON.stringify({status: code, item: req.params.item, layer: (req.params.layer || 0)}))
         res.status(code).json(response)
       })
     }
-  }
-
-  /**
-   * Builds a failure message to the client
-   * @param {object} req - the incoming request
-   * @param {object} res - the outgoing response
-   * @param {object} error - an error object from some attempt to get data
-   */
-  controller._failureMsg = function (error) {
-    // todo change the outgoing format to something flat that makes sense
-    // be defensive about errors that don't have a body
-    error.body = error.body || {}
-    return {
-      message: error.message,
-      code: error.body.code,
-      request: error.url,
-      response: error.body.message,
-      timestamp: error.timestamp || new Date()
-    }
-
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,4 +31,24 @@ Utils.createCacheKey = function (params, query) {
   return crypto.createHash('md5').update(toHash).digest('hex')
 }
 
+/**
+ * Builds a failure message to the client
+ * @param {object} req - the incoming request
+ * @param {object} res - the outgoing response
+ * @param {object} error - an error object from some attempt to get data
+ */
+Utils.failureMsg = function (error) {
+  // todo change the outgoing format to something flat that makes sense
+  // be defensive about errors that don't have a body
+  error.body = error.body || {}
+  return {
+    message: error.message,
+    code: error.body.code,
+    request: error.url,
+    response: error.body.message,
+    timestamp: error.timestamp || new Date()
+  }
+
+}
+
 module.exports = Utils

--- a/routes/index.js
+++ b/routes/index.js
@@ -26,5 +26,6 @@ module.exports = {
   'get /agol/:id/:item/FeatureServer/:layer/geohash': 'getGeohash',
   'get /agol/:id/:item/:layer/expiration': 'getExpiration',
   'put /agol/:id/:item/:layer/expiration': 'setExpiration',
-  'post /agol/:id/:item/:layer/expiration': 'setExpiration'
+  'post /agol/:id/:item/:layer/expiration': 'setExpiration',
+  'get /test': 'testRoute'
 }

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -544,7 +544,6 @@ describe('AGOL Model', function () {
         err.timestamp.should.equal('timeoclock')
         err.body.code.should.equal(499)
         err.url.should.equal('http://error.com')
-        console.log(err)
         err.body.message.should.equal('Token Required')
         done()
       })

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -542,9 +542,10 @@ describe('AGOL Model', function () {
         should.exist(err)
         err.message.should.equal('Unable to get the layer metadata')
         err.timestamp.should.equal('timeoclock')
-        err.code.should.equal(499)
-        err.request.should.equal('http://error.com')
-        err.response.should.equal('Token Required')
+        err.body.code.should.equal(499)
+        err.url.should.equal('http://error.com')
+        console.log(err)
+        err.body.message.should.equal('Token Required')
         done()
       })
     })
@@ -580,7 +581,7 @@ describe('AGOL Model', function () {
       }
 
       agol.setFail(key, error, function (info) {
-        info.status.should.equal('processing')
+        info.status.should.equal('Failed')
         info.generating.error.should.exist
         info.generating.error.timestamp.should.equal('time')
         info.generating.error.code.should.equal(999)


### PR DESCRIPTION
@ngoldman This could use a solid read. I'm going to hold off on adding a lot of tests around the new download method until I refactor it further into more methods.

This PR begins to refactor the massive `findItemData` method and moves all status returns to a single method called `_returnStatus`

Some key points:
- we will always return 502 if there was an error emanating from AGOL, or a Feature Service
- we will have a consistent structure returned to clients in the payload of any error
 -> the structure kinda sucks but flattening it would be a breaking change so I'm going to hold off
- resources will either have a status of processing or failed, this allows us to add logic later to keep things in a failed state for a controllable amount of time
- feature service logic in `getFeatureServiceInfo` has been replaced with methods in Featureservice.js