### PR TITLE
Handle errors correctly from request workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Errors on trying to fetch items pass through `_returnStatus`
+* Socket connections to portals are kept alive
+* Errors in request workers are handled centrally
+
+### Fixed
+* Errors are now passed correctly from feature service to the db and the client
+
 ## [1.3.0] - 2015-08-20
 ### Changed
 * Feature service logic is fully delegated to featureservice.js

--- a/controller/index.js
+++ b/controller/index.js
@@ -439,15 +439,16 @@ var Controller = function (agol, BaseController) {
           agol.log('error', 'Failed to get count of rows in the DB' + ' ' + err)
           // don't let db messages leak out
         }
+
+        // if we failed to get info from AGOL the info object will be null so initialize it
+        if (!info) info = {retrieved_at: Date.now(), status: 'Failed'}
+
         // if we have a passed in error or the info doc says error then this request is errored and we should send a 502 with status failed
         var errored = (error && error.message) || (info.generating && info.generating.error)
         var code = errored ? 502 : 202
         var status = errored ? 'Failed' : (info.status || 'Processing')
-        if (!info) {
-          info = {retrieved_at: Date.now()}
-          status = 'Failed'
-        }
-        // we need some logic around handling long standing processing times
+
+        // TODO: we need some logic around reporting long processing times
         var processingTime = (Date.now() - info.retrieved_at) / 1000 || 0
 
         // set up a shell of the response

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,11 +42,13 @@ Utils.failureMsg = function (error) {
   // be defensive about errors that don't have a body
   error.body = error.body || {}
   return {
-    message: error.message,
-    code: error.body.code,
-    request: error.url,
-    response: error.body.message,
-    timestamp: error.timestamp || new Date()
+    error: {
+      message: error.message,
+      code: error.code || error.body.code || 500,
+      request: error.url,
+      response: error.body.message,
+      timestamp: error.timestamp || new Date()
+    }
   }
 
 }

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -856,9 +856,9 @@ describe('AGOL Controller', function () {
         .end(function (err, res) {
           res.body.status.should.equal('Failed')
           should.exist(res.body.generating)
-          res.body.generating.code.should.equal(500)
-          res.body.generating.response.should.equal('Failed to perform query')
-          res.body.generating.request.should.equal('http://www.failure.com')
+          res.body.generating.error.code.should.equal(500)
+          res.body.generating.error.response.should.equal('Failed to perform query')
+          res.body.generating.error.request.should.equal('http://www.failure.com')
           controller.testMethod.restore()
           should.not.exist(err)
           done()

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -30,7 +30,7 @@ describe('AGOL Model', function () {
       })
 
       sinon.stub(agol, 'req', function (url, callback) {
-        callback(null, '')
+        callback(null, {body: JSON.stringify({})})
       })
       done()
     })
@@ -337,8 +337,8 @@ describe('AGOL Model', function () {
       agol.getItem('host', 'id', {}, function (err, item) {
         should.exist(err)
         err.message.should.equal('Failed while trying to get item information')
-        err.response.should.equal('You do not have permissions to access this resource or perform this operation.')
-        err.code.should.equal(403)
+        err.body.message.should.equal('You do not have permissions to access this resource or perform this operation.')
+        err.body.code.should.equal(403)
         done()
       })
     })
@@ -355,7 +355,7 @@ describe('AGOL Model', function () {
       })
 
       sinon.stub(agol, 'req', function (url, callback) {
-        callback(null, {})
+        callback(null, {body: JSON.stringify({})})
       })
 
       done()


### PR DESCRIPTION
This PR allows request workers to transmit error messages from FeatureService.js to the main Koop Server. 

The key is setting a `koopError` object on the job object in Redis that can be pulled down on any failure. Using our own callback instead of calling Kue's callback immediately allows us to handle this logic.