### PR TITLE
always download existing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Metadata is always downloaded if available
+
 ## [1.3.4]
 ### Fixed
 * Feature server layer info is routed correctly

--- a/models/agol.js
+++ b/models/agol.js
@@ -230,7 +230,7 @@ var AGOL = function (koop) {
         error.url = url
         return callback(error)
       }
-      if (options.getMetadata && json.typeKeywords && json.typeKeywords.indexOf('Metadata') !== -1) {
+      if (json.typeKeywords && json.typeKeywords.indexOf('Metadata') !== -1) {
         agol.getItemMetadata(host, itemId, json, callback)
       } else {
         callback(null, json)

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -81,7 +81,7 @@ describe('AGOL Model', function () {
     })
 
     it('should call getItemMetadata to json', function (done) {
-      agol.getItem('host1', 'item1', {getMetadata: true}, function (err, json) {
+      agol.getItem('host1', 'item1', {}, function (err, json) {
         should.not.exist(err)
         json.metadata.should.equal(true)
         done()


### PR DESCRIPTION
This PR removes the option for getting metadata and always downloads it from AGOL when it's available. Before a regression in the code, this option was hard coded anyways. It is a simpler solution to remove the option altogether than fix the hardcoding.

ping @ngoldman @AKHarris 