### PR TITLE
drop failed resources after 30 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Failed resources do not stay failed permanently, instead they drop after 30 minutes
+
 ## [1.4.0] 
 ### Added
 * Logging throughout the download request cycle

--- a/controller/index.js
+++ b/controller/index.js
@@ -1005,12 +1005,11 @@ var Controller = function (agol, BaseController) {
             return controller.returnGeohash(req, res, path, fileInfo)
           }
           return res.status(202).json({ status: 'processing' })
-
         } else {
           // need to know if the data are expired or not
-          var isExpired = (info.retrieved_at && fileInfo && fileInfo.LastModified) ?
-            (new Date(info.retrieved_at) > new Date(fileInfo.LastModified)) :
-            false
+          var isExpired = (info.retrieved_at && fileInfo && fileInfo.LastModified)
+            ? (new Date(info.retrieved_at) > new Date(fileInfo.LastModified))
+            : false
 
           if (!exists) {
             // doesnt exist; must create the new aggregation file
@@ -1063,7 +1062,6 @@ var Controller = function (agol, BaseController) {
   }
 
   return controller
-
 }
 
 module.exports = Controller

--- a/controller/index.js
+++ b/controller/index.js
@@ -195,12 +195,19 @@ var Controller = function (agol, BaseController) {
 
     req.tableKey = controller._createTableKey('agol', req.params)
 
-    // returns data in the data
     agol.getInfo(req.tableKey, function (err, info) {
+      console.log('hi', err, info)
       if (err) agol.log.info(err.message)
+
       if (info && info.status && info.status === 'Failed') {
-        // TODO logic so that things don't stay failed for more than x amount of time
-        return controller._returnStatus(req, res, info)
+        if (Date.now() - info.retrieved_at > (30 * 60 * 1000)) {
+          agol.dropItem(req.params.id, req.params.item, {layer: req.params.layer}, function (err) {
+            if (err) agol.log.error('foo')
+            return controller.findItemData(req, res)
+          })
+        } else {
+          return controller._returnStatus(req, res, info)
+        }
       }
 
       // parse the spatial ref if we have one,

--- a/controller/index.js
+++ b/controller/index.js
@@ -196,13 +196,13 @@ var Controller = function (agol, BaseController) {
     req.tableKey = controller._createTableKey('agol', req.params)
 
     agol.getInfo(req.tableKey, function (err, info) {
-      console.log('hi', err, info)
       if (err) agol.log.info(err.message)
 
       if (info && info.status && info.status === 'Failed') {
         if (Date.now() - info.retrieved_at > (30 * 60 * 1000)) {
           agol.dropItem(req.params.id, req.params.item, {layer: req.params.layer}, function (err) {
-            if (err) agol.log.error('foo')
+            if (err) agol.log.error('Unabled to drop failed resource: ' + req.params.item + '_' + req.params.layer)
+            agol.log.info('Successfully reset failed resource: ' + req.params.item + '_' + req.params.layer)
             return controller.findItemData(req, res)
           })
         } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,6 @@ Utils.failureMsg = function (error) {
       timestamp: error.timestamp || new Date()
     }
   }
-
 }
 
 module.exports = Utils

--- a/models/agol.js
+++ b/models/agol.js
@@ -48,7 +48,6 @@ var AGOL = function (koop) {
     agol.worker_q.on('job progress', function (id, progress) {
       agol.log.info('progress ' + id + ' - ' + progress + '%')
     })
-
   }
 
   // check to see if koop is configured to force workers on all data
@@ -159,7 +158,6 @@ var AGOL = function (koop) {
           })
         })
       })
-
     } else {
       var dir = [ itemId, layerId ].join('_')
       koop.Cache.remove('agol', itemId, options, function (err, res) {
@@ -168,10 +166,8 @@ var AGOL = function (koop) {
         }
         agol._removeExportDirs(dir, callback)
       })
-
     }
   }
-
   /**
    * Method to remove all the data in each export dir
    * this logic is being used in 4 places
@@ -431,7 +427,6 @@ var AGOL = function (koop) {
           })
         }
       })
-
     })
   }
 
@@ -622,7 +617,6 @@ var AGOL = function (koop) {
           })
         })
       })
-
     })
   }
 
@@ -693,7 +687,6 @@ var AGOL = function (koop) {
 
       itemJson.data = entry
       callback(null, itemJson)
-
     })
   }
 
@@ -1010,7 +1003,6 @@ var AGOL = function (koop) {
         })
       })
     })
-
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "documentation": "^2.0.1",
     "istanbul": "^0.3.17",
     "koop": "^2.7.0",
+    "lodash": "^2.4.2",
     "mocha": "~2.2.5",
     "should": "~3.3.1",
     "sinon": "~1.10.2",

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -475,7 +475,6 @@ describe('AGOL Controller', function () {
           done()
         })
     })
-
   })
 
   describe('getting geohash json', function () {
@@ -878,7 +877,6 @@ describe('AGOL Controller', function () {
           should.not.exist(err)
           done()
         })
-
     })
 
     it('should return 502 when the info doc says the resource has failed', function (done) {
@@ -939,5 +937,4 @@ describe('AGOL Controller', function () {
         })
     })
   })
-
 })

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -1,9 +1,10 @@
-/* global before, after, it, describe, should */
+/* global before, beforeEach, after, afterEach, it, describe, should */
 var should = require('should') // eslint-disable-line
 var sinon = require('sinon')
 var request = require('supertest')
 var fs = require('fs')
 var koop = require('koop')({logfile: './test.log'})
+var _ = require('lodash')
 
 var Provider = require('../index.js')
 var agol = Provider.model(koop)
@@ -311,6 +312,81 @@ describe('AGOL Controller', function () {
           res.should.have.status(202)
           agol.getInfo.called.should.equal(true)
           agol.getCount.called.should.equal(true)
+          done()
+        })
+    })
+  })
+
+  describe('getting an item that is in a failed state', function () {
+    beforeEach(function (done) {
+      sinon.stub(controller, '_returnStatus', function (req, res, info) {
+        res.status(500).send({})
+      })
+
+      sinon.stub(agol, 'dropItem', function (id, item, options, callback) {
+        callback(null)
+      })
+
+      sinon.stub(controller, 'download', function (req, res, info) {
+        res.status(202).send({})
+      })
+
+      sinon.stub(agol, 'find', function (id, callback) {
+        callback(null, {id: 'test', host: 'http://dummy.host.com'})
+      })
+
+      done()
+    })
+
+    afterEach(function (done) {
+      controller._returnStatus.restore()
+      agol.dropItem.restore()
+      controller.download.restore()
+      agol.find.restore()
+      done()
+    })
+
+    it('should call drop item and getItemData if failure was more than 30 minutes ago', function (done) {
+      // yes is this a hack, but onSecondCall is not available when you instantiate sinon.stub with an object and method
+      var infoFunc = _.clone(agol.getInfo)
+      var stub = sinon.stub()
+      stub.onFirstCall().callsArgWith(1, null, {
+        status: 'Failed',
+        retrieved_at: Date.now() - (45 * 60 * 1000)
+      })
+      stub.onSecondCall().callsArgWith(1, new Error())
+      agol.getInfo = stub
+
+      request(koop)
+        .get('/agol/test/itemId/3.zip')
+        .expect(202)
+        .end(function (err, res) {
+          should.not.exist(err)
+          agol.dropItem.called.should.equal(true)
+          controller._returnStatus.called.should.equal(false)
+          controller.download.called.should.equal(true)
+          agol.getInfo = infoFunc
+          done()
+        })
+    })
+
+    it('should call _returnStatus if failure was less than 30 minutes ago', function (done) {
+      sinon.stub(agol, 'getInfo', function (key, callback) {
+        callback(null, {
+          status: 'Failed',
+          retrieved_at: Date.now() - (15 * 60 * 1000)
+        })
+      })
+
+      request(koop)
+        .get('/agol/test/itemId/3.zip')
+        .expect(500)
+        .end(function (err, res) {
+          agol.getInfo.restore()
+          should.not.exist(err)
+          agol.dropItem.called.should.equal(false)
+          controller._returnStatus.called.should.equal(true)
+          controller.download.called.should.equal(false)
           done()
         })
     })

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -87,7 +87,6 @@ describe('AGOL Model', function () {
         done()
       })
     })
-
   })
 
   describe('when setting the expiration date on a resource', function () {
@@ -720,7 +719,5 @@ describe('AGOL Model', function () {
         done()
       })
     })
-
   })
-
 })

--- a/workers/request-worker.js
+++ b/workers/request-worker.js
@@ -133,5 +133,4 @@ function makeRequest (job, callback) {
       })
     })
   })
-
 }


### PR DESCRIPTION
This PR fixes a critical bug where datasets in a failed state are never expired automatically. Now they will expire after a 30 minute period.

Resolves #28 