### PR TITLE
fix bugs in controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* No longer continuing execution after handling a failed resource
+* Cache keys are the same when formats are passed in
+
+### Changed
+* Removed some cruft and unused logic from the controller
+
 ## [1.4.2] - 2015-09-11
 ### Fixed
 * Koop logger is called correctly (and the same way) everywhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * No longer continuing execution after handling a failed resource
 * Cache keys are the same when formats are passed in
+* Cache keys are no longer the same when different where clauses are passed in
 
 ### Changed
 * Removed some cruft and unused logic from the controller

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,12 @@ Utils.forceHttps = function (url) {
 Utils.createCacheKey = function (params, query) {
   // sort the req.query before we hash so we are consistent
   // there is a potential memory issue with using _(obj).omit(array)
-  var sorted_query = _.keys(_.omit(query, ['url_only', 'format', 'callback'])).sort()
+  var sorted_query = {}
+  var cacheParams = _.omit(query, ['url_only', 'format', 'callback'])
+
+  _(cacheParams).keys().sort().each(function (key) {
+    sorted_query[key] = query[key]
+  })
 
   // this is called from a greedy route so we need to parse the layer id off the captured param
   var layer

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,9 +39,18 @@ Utils.createCacheKey = function (params, query) {
   return crypto.createHash('md5').update(toHash).digest('hex')
 }
 
+// TODO: Get rid of this wohle logic block, it's a huge hack and prone to error
 function getLayer (candidate) {
-  var parts = candidate.split('/')
-  var layer = parts[0] === 'FeatureServer' ? parts[1] : parts[0]
+  var parts
+  var layer
+  if (candidate.match(/FeatureServer/)) {
+    parts = candidate.split('/')
+    layer = parts[0] === 'FeatureServer' ? parts[1] : parts[0]
+  } else if (candidate.match(/\.csv|\.kml|\.zip|\.geojson|\.json|\.shp|\.png/)) {
+    parts = candidate.split('.')
+    layer = parts[0]
+  }
+
   return layer
 }
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -17,7 +17,7 @@ describe('Utils', function () {
     }
     var params4 = {
       item: 'item',
-      0: '0.csv'
+      0: '1.csv'
     }
     var reference_query = {
       foo: 1,
@@ -27,12 +27,12 @@ describe('Utils', function () {
       bar: 1,
       foo: 1
     }
-    var test_query3 = {
+    var test_query2 = {
       foo: 1,
       bar: 2,
       where: 'where clause1'
     }
-    var test_query2 = {
+    var test_query3 = {
       foo: 1,
       bar: 2,
       where: 'where clause2'
@@ -60,7 +60,7 @@ describe('Utils', function () {
     })
 
     it('should create the same cache key when formats are included in the request', function (done) {
-      var key1 = Utils.createCacheKey(params, reference_query)
+      var key1 = Utils.createCacheKey(params2, reference_query)
       var key2 = Utils.createCacheKey(params4, reference_query)
       key1.should.equal(key2)
       done()

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -27,6 +27,16 @@ describe('Utils', function () {
       bar: 1,
       foo: 1
     }
+    var test_query3 = {
+      foo: 1,
+      bar: 2,
+      where: 'where clause1'
+    }
+    var test_query2 = {
+      foo: 1,
+      bar: 2,
+      where: 'where clause2'
+    }
     var expected_key = Utils.createCacheKey(params, reference_query)
 
     it('should create the same cache key when query params are out of order', function (done) {
@@ -53,6 +63,13 @@ describe('Utils', function () {
       var key1 = Utils.createCacheKey(params, reference_query)
       var key2 = Utils.createCacheKey(params4, reference_query)
       key1.should.equal(key2)
+      done()
+    })
+
+    it('should create a difference cache key when there is different where clauses', function (done) {
+      var key1 = Utils.createCacheKey(params, test_query2)
+      var key2 = Utils.createCacheKey(params, test_query3)
+      key1.should.not.equal(key2)
       done()
     })
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -15,6 +15,10 @@ describe('Utils', function () {
       item: 'item',
       0: 'FeatureServer/0'
     }
+    var params4 = {
+      item: 'item',
+      0: '0.csv'
+    }
     var reference_query = {
       foo: 1,
       bar: 1
@@ -41,6 +45,13 @@ describe('Utils', function () {
     it('should not include the featureserver method in cache keys', function (done) {
       var key1 = Utils.createCacheKey(params, reference_query)
       var key2 = Utils.createCacheKey(params3, reference_query)
+      key1.should.equal(key2)
+      done()
+    })
+
+    it('should create the same cache key when formats are included in the request', function (done) {
+      var key1 = Utils.createCacheKey(params, reference_query)
+      var key2 = Utils.createCacheKey(params4, reference_query)
       key1.should.equal(key2)
       done()
     })


### PR DESCRIPTION
This PR prevents execution from continuing when handling a resource that is in a failed state. It will either return status or drop the resource and call findItemData recursively rather than also continuing to controller.download. 

It also clears up an issue where cache keys are created incorrectly when download formats are passed in, and removes some crufty code from the controller.