### PR TITLE
request worker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Logger is passed to featureservice
+* On error inserting after a drop call, failure status is not set in db
+
 ## [1.4.3] - 2015-09-16 
 ### Fixed
 * No longer continuing execution after handling a failed resource

--- a/models/agol.js
+++ b/models/agol.js
@@ -12,7 +12,6 @@ var AGOL = function (koop) {
    */
   var agol = new koop.BaseModel(koop)
   agol.log = koop.log
-  console.log(agol.log)
 
   // base path to use for every host
   agol.agol_path = '/sharing/rest/content/items/'

--- a/models/agol.js
+++ b/models/agol.js
@@ -12,6 +12,7 @@ var AGOL = function (koop) {
    */
   var agol = new koop.BaseModel(koop)
   agol.log = koop.log
+  console.log(agol.log)
 
   // base path to use for every host
   agol.agol_path = '/sharing/rest/content/items/'
@@ -990,6 +991,7 @@ var AGOL = function (koop) {
           if (err) agol.log.error(err)
           try {
             error = JSON.parse(value)
+            if (error.type === 'db') return removeJob(job)
           } catch (e) {
             error = new Error('Unknown failure while paging')
             agol.log.error('Unknown failure from paging job ' + e + ' ' + key)

--- a/workers/request-worker.js
+++ b/workers/request-worker.js
@@ -95,7 +95,7 @@ function makeRequest (job, callback) {
     koop.log.info('starting job ' + job.id + ': ' + job.data.itemId + '_' + job.data.layerId)
     var completed = 0
     var len = job.data.pages.length
-    var featureService = new FeatureService(job.data.serviceUrl, {})
+    var featureService = new FeatureService(job.data.serviceUrl, {logger: koop.log})
 
     // aggregate responses into one json and call done we have all of them
     // start the requests
@@ -111,7 +111,10 @@ function makeRequest (job, callback) {
         koop.Cache.insertPartial('agol', job.data.itemId, geojson, job.data.layerId, function (err) {
           if (err) {
             featureService.pageQueue.kill()
-            throw err
+            koop.log.error('err')
+            var error = new Error('Error inserting rows into the db')
+            error.type = 'db'
+            throw error
           }
           completed++
           koop.log.info(completed + ' pages of ' + len + ' completed. ' + job.id + ': ' + job.data.itemId + '_' + job.data.layerId)


### PR DESCRIPTION
This fixes two things:
1. Logger is passed to feature service in request worker
2. Failure is not set on the info doc when the request worker fails while inserting data