### PR TITLE
Send 500 on empty geohash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Now sending 500 if geohash on AWS is empty
+
 ## [1.4.4] - 2015-09-23
 ### Changed
 * Logger is passed to featureservice

--- a/controller/index.js
+++ b/controller/index.js
@@ -1033,6 +1033,7 @@ var Controller = function (agol, BaseController) {
     if (path.substr(0, 4) === 'http') {
       // Proxy to s3 urls allows us to not show the URL
       https.get(path, function (proxyRes) {
+        if (proxyRes.headers['content-length'] === 0) return res.status(500).json({error: 'Empty geohash'})
         proxyRes.pipe(res)
       })
     } else {


### PR DESCRIPTION
We have seen a 200 on an empty geohash in production. At least this way we will get 500s so we can investigate the root cause.