### PR TITLE
override queue prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
 * Now sending 500 if geohash on AWS is empty
+* Force override of agol.worker_q prefix
 
 ## [1.4.4] - 2015-09-23
 ### Changed

--- a/models/agol.js
+++ b/models/agol.js
@@ -25,13 +25,14 @@ var AGOL = function (koop) {
   // create a request queue if configured to page large data sets to workers
   if (koop.config.agol && koop.config.agol.request_workers) {
     agol.worker_q = kue.createQueue({
-      prefix: koop.config.agol.request_workers.redis.prefix || 'q',
       disableSearch: true,
       redis: {
         port: koop.config.agol.request_workers.redis.port || 6379,
         host: koop.config.agol.request_workers.redis.host || '127.0.0.1'
       }
     })
+    // Note there is a bug in kue where multiple queues in the same process with step on the other's prefix
+    agol.worker_q.client.prefix = koop.config.agol.request_workers.redis.prefix || 'q'
 
     // remove completed jobs from the queue
     agol.worker_q.on('job complete', function (id) {


### PR DESCRIPTION
This papers over a bug in Kue where if you are running multiple queues the second time you create a queue the redis client prefix does not get set